### PR TITLE
Handle em open_file & Close2

### DIFF
--- a/t2fs/src/t2fs.c
+++ b/t2fs/src/t2fs.c
@@ -13,6 +13,7 @@
 
 
 typedef struct file_t2fs {
+    FILE2 handle;
     char filename[MAX_FILE_NAME_SIZE+1];
     int current_pointer;
 }FILE_T2FS;
@@ -268,14 +269,15 @@ FILE2 create2 (char *filename) {
         return -1;
     }
 
+    FILE2 handle_created_file = open2(filename);
+
     /// File
     FILE_T2FS new_open_file;
+    new_open_file.handle = handle_created_file;
     new_open_file.current_pointer = 0;
     strcpy(new_open_file.filename, filename);
 
     open_files[pos_insercao_open_file] = new_open_file; // Insere em arquivos abertos
-
-    FILE2 handle_created_file = open2(filename);
 
     if (handle_created_file < 0){
         return -1;

--- a/t2fs/src/t2fs.c
+++ b/t2fs/src/t2fs.c
@@ -306,7 +306,24 @@ FILE2 open2 (char *filename) {
 Função:	Função usada para fechar um arquivo.
 -----------------------------------------------------------------------------*/
 int close2 (FILE2 handle) {
-	return -1;
+    // handle: identificador de arquivo para fechar
+    int pos_file = 0;
+    while (open_files[pos_file].handle != handle && pos_file < MAX_OPEN_FILE){
+        pos_file++;
+    }
+
+    if (pos_file >= MAX_OPEN_FILE){ // Não encontrou arquivo
+        return -1;
+	}
+
+	// Caso arquivo já esteja marcado como fechado (current_pointer == -1)
+	if (open_files[pos_file].current_pointer < 0){ // (<= 0)??
+        return -1;
+	}
+
+	open_files[pos_file].current_pointer = -1; // Marca arquivo como fechado (current_pointer == -1)
+
+	return 0;
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
Adicionado `handle` como variável em estrutura para identificar arquivo diretamente por ele.

Estruturação de `close2()`:
- Função usada para fechar um arquivo.
- Marca arquivo como fechado (current_pointer = -1) em função.
- Retorna -1 em caso de erro.